### PR TITLE
Gist ID should be a hex number, not just an int

### DIFF
--- a/lib/nanoc/toolbox/helpers/github_gist.rb
+++ b/lib/nanoc/toolbox/helpers/github_gist.rb
@@ -26,7 +26,7 @@ module Nanoc::Toolbox::Helpers
     # @param [Integer] gist_id - the ID of the Gist
     # @param [String] filename - the optional filename to display
     def gist(gist_id, filename=nil)
-      raise ArgumentError, "Gist ID should be a Integer" unless gist_id.is_a? Integer 
+      raise ArgumentError, "Gist ID should be a hex number" unless (gist_id.to_s).match(/^\h+$/)
       url = "#{GIST_HOST}/#{gist_id}.#{GIST_EXT}"
 
       if filename

--- a/spec/helpers/github_gist_spec.rb
+++ b/spec/helpers/github_gist_spec.rb
@@ -14,10 +14,11 @@ describe Nanoc::Toolbox::Helpers::GithubGist do
         lambda{ subject.gist }.should raise_error(ArgumentError)
       end
 
-      it "ensures that Gist ID is an Integer" do
-        lambda{ subject.gist('abc') }.should raise_error(ArgumentError)
-        lambda{ subject.gist('123') }.should raise_error(ArgumentError)
+      it "ensures that Gist ID is an Integer or a hex number" do
+        lambda{ subject.gist('123') }.should_not raise_error(ArgumentError)
         lambda{ subject.gist(12345) }.should_not raise_error(ArgumentError)
+        lambda{ subject.gist('decafbad123') }.should_not raise_error(ArgumentError)
+        lambda{ subject.gist('+supercool+xxx') }.should raise_error(ArgumentError)
       end
 
       it "returns the script tag for a gist" do


### PR DESCRIPTION
this fixes #9 
- Github changed from using numeric IDs for gists to using hex numbers. This fixes the gem to handle that.
- Also updated spec: gists should be hex nums (and fail on anything else)
- did **not** bump minor version; the Travis build fails when i do so, not sure how to get around that.
